### PR TITLE
Always use -Wl,-Bsymbolic flag even in static build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,53 +102,17 @@ AC_SUBST([FFMPEG_LIBS])
 CPPFLAGS="$CPPFLAGS -D__STDC_CONSTANT_MACROS"
 CFLAGS="$_CFLAGS $FFMPEG_CFLAGS"
 
-AC_DEFUN([TEST_FFMPEG],
-         [AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-            #include <libavformat/avformat.h>
-            #include <libswscale/swscale.h>
-            ]],[[
-                avformat_network_init();
-                swscale_version();
-            ]])], [eval $1=yes], [eval $1=no])
-        ])
-
-AC_MSG_CHECKING([whether FFmpeg works])
-LIBS="$_LIBS $FFMPEG_LIBS"
-TEST_FFMPEG([FFMPEG_WORKS])
-AC_MSG_RESULT([$FFMPEG_WORKS])
-if test "$FFMPEG_WORKS" = no; then
-AC_MSG_FAILURE([cannot link with FFmpeg])
-fi
-
+dnl The -Wl,-Bsymbolic flag is not strictly required in all cases, but enabling it by default is safer.
+dnl For example, if a shared library X links against ffms2 built as a static library, which in turn links to FFmpeg statically, this flag is necessary.
+dnl There is no reliable way to determine automatically when it is needed.
+dnl For more details, see FFmpeg's documentation on advanced linking: https://ffmpeg.org/platform.html#Advanced-linking-configuration
 src_core_libffms2_la_LDFLAGS=""
-AC_MSG_CHECKING([whether -Wl,-Bsymbolic is needed])
-if test "$enable_shared" = yes; then
-    _LDFLAGS="$LDFLAGS"
-    LDFLAGS="$LDFLAGS -shared $lt_prog_compiler_pic"
-    TEST_FFMPEG([no_bsymbolic])
-    if test "$no_bsymbolic" = "no"; then
-        LDFLAGS="$LDFLAGS -Wl,-Bsymbolic"
-        TEST_FFMPEG([bsymbolic])
-        if test "$bsymbolic" = "yes"; then
-            src_core_libffms2_la_LDFLAGS="$src_core_libffms2_la_LDFLAGS -Wl,-Bsymbolic"
-        else
-            AC_MSG_RESULT($bsymbolic)
-            AC_MSG_FAILURE([cannot build ffms2 as a shared library])
-        fi
-    else
-        bsymbolic=no
-    fi
-    LDFLAGS="$_LDFLAGS"
-    src_core_libffms2_la_LDFLAGS="$src_core_libffms2_la_LDFLAGS -version-info $VERSION_INFO"
-else
-    bsymbolic=no
-fi
+AX_CHECK_LINK_FLAG([-Wl,-Bsymbolic], [src_core_libffms2_la_LDFLAGS="$src_core_libffms2_la_LDFLAGS -Wl,-Bsymbolic -version-info $VERSION_INFO"])
 AC_SUBST([src_core_libffms2_la_LDFLAGS])
 
 CFLAGS="$_CFLAGS"
 CPPFLAGS="$_CPPFLAGS"
 LIBS="$_LIBS"
-AC_MSG_RESULT($bsymbolic)
 
 if echo "$host" | $GREP "mingw" >/dev/null 2>&1; then
     LTUNDEF="-no-undefined"

--- a/m4/m4_ax_check_link_flag.m4
+++ b/m4/m4_ax_check_link_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_LINK_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the linker or gives an error.
+#   (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_LINK_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,COMPILE}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_LINK_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_ldflags_$4_$1])dnl
+AC_CACHE_CHECK([whether the linker accepts $1], CACHEVAR, [
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS $4 $1"
+  AC_LINK_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  LDFLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_LINK_FLAGS


### PR DESCRIPTION
Even bestsource always use -Wl,-Bsymbolic. See: https://github.com/vapoursynth/bestsource/blob/1c19c9838c725e3c92987a32456e9d9defbfcc95/meson.build#L68

The file m4/m4_ax_check_link_flag.m4 is a copy of https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html

Fix https://github.com/FFMS/ffms2/issues/458